### PR TITLE
Refactor find key method

### DIFF
--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -93,17 +93,15 @@ class Decryptor < Machine
 
   def find_working_keys(encrypted_message, date)
     potential_keys = find_all_potential_keys(encrypted_message, date)
-    seperated_keys = []
-    potential_keys.first.find do |key_1|
+    potential_keys.first.each do |key_1|
       next if !key_is_valid?(potential_keys[1], key_1)
       key_2 = find_next_valid_key(potential_keys[1], key_1)
       next if !key_is_valid?(potential_keys[2], key_2)
       key_3 = find_next_valid_key(potential_keys[2], key_2)
       next if !key_is_valid?(potential_keys[3], key_3)
       key_4 = find_next_valid_key(potential_keys[3], key_3)
-      seperated_keys << [key_1, key_2, key_3, key_4]
+      return [key_1, key_2, key_3, key_4]
     end
-    seperated_keys.flatten
   end
 
   def key_is_valid?(potential_key_set, key)
@@ -122,7 +120,7 @@ class Decryptor < Machine
         (key_value + 54).to_s,
         (key_value + 81).to_s,
       ]
-    end
+    end.map { |key_values|  key_values.reject { |key_value| key_value.to_i >= 100 }}
   end
 
   def first_key_value(key)

--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -44,7 +44,7 @@ class Decryptor < Machine
     return char if !@alphabet.include?(char)
       new_index = (@alphabet.find_index(char) - shift) % 27
       @alphabet[new_index]
-  end  
+  end
 
   def find_shifts(encrypted_message, date)
     split_encrypted = split_message(encrypted_message)

--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -130,13 +130,11 @@ class Decryptor < Machine
 
   def shifts_minus_offsets(encrypted_message, date)
     offsets = date_to_offsets(date)
-    key_values = []
-    find_shifts(encrypted_message, date).each_with_index do |shift, index|
+    find_shifts(encrypted_message, date).each_with_index.map do |shift, index|
       shifted = shift - offsets[index]
       shifted %= 27 if shifted < 0
-      key_values << shifted
+      shifted
     end
-    key_values
   end
 
 end

--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -32,9 +32,9 @@ class Decryptor < Machine
   def crack_message(encrypted_message, date)
     cracked = ""
     shifts = find_shifts(encrypted_message, date)
-    split_message(encrypted_message).each do |chars|
-      chars.zip(shifts).each do |char, shift_value|
-        cracked.concat(decrypt_character(char, shift_value))
+    split_message(encrypted_message).each do |encrypted_chars|
+      encrypted_chars.zip(shifts).each do |encrypted_char, shift_value|
+        cracked.concat(decrypt_character(encrypted_char, shift_value))
       end
     end
     cracked
@@ -42,8 +42,8 @@ class Decryptor < Machine
 
   def decrypt_character(char, shift)
     return char if !@alphabet.include?(char)
-      new_index = (@alphabet.find_index(char) - shift) % 27
-      @alphabet[new_index]
+    new_index = (@alphabet.find_index(char) - shift) % 27
+    @alphabet[new_index]
   end
 
   def find_shifts(encrypted_message, date)

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -13,9 +13,9 @@ class Encryptor < Machine
   def encrypt_message(message, key, date)
     encrypted = ""
     shifts = create_shifts(key, date)
-    split_message(message).each do |chars|
-      chars.zip(shifts).each do |char, shift_value|
-        encrypted.concat(encrypt_character(char, shift_value))
+    split_message(message).each do |message_chars|
+      message_chars.zip(shifts).each do |message_char, shift_value|
+        encrypted.concat(encrypt_character(message_char, shift_value))
       end
     end
     encrypted

--- a/lib/machine.rb
+++ b/lib/machine.rb
@@ -6,13 +6,13 @@ class Machine
   end
 
   def create_shifts(key, date)
-    split_key(key).zip(date_to_offsets(date)).map { |nums| nums.reduce(:+) }
+    split_key(key).zip(date_to_offsets(date)).map { |key_offset| key_offset.reduce(:+) }
   end
 
   def split_key(key)
     key_array = []
-    key.chars.each_cons(2){|chars| key_array << chars.join}
-    key_array.map { |char| char.to_i }
+    key.chars.each_cons(2){|key_chars| key_array << key_chars.join}
+    key_array.map { |key_char| key_char.to_i }
   end
 
   def date_to_offsets(date)

--- a/test/decryptor_test.rb
+++ b/test/decryptor_test.rb
@@ -85,28 +85,43 @@ class DecryptorTest < Minitest::Test
     assert_equal 14, @decryptor.shift_amount("s", "e")
   end
 
-  def test_find_key_with_date_and_encrypted_mressage
+  def test_find_key_with_date_and_encrypted_message
     assert_equal "08304", @decryptor.find_key("vjqtbeaweqihssi", "291018")
-
     assert_equal "14140", @decryptor.find_key("mzwet fmuen'owek'rwzifefuegmfwfeuys.
      gmgwsqlrgattsmyeqdrggrx!!!twaq", "190420")
-    assert_equal "20258", @decryptor.find_key("sjuwzkdd pl'ugcb'buqoqcx pedlgdw iq.
-    kedmgqhrbeszdqddpovxreic!!!zgzh", "190420")
+    assert_equal "14811", @decryptor.find_key("mfictgskul 'ocri'yiximrdultkfcscuee.
+    gtkgceolytzt ekylcbrntpx!!!tcno", "200420")
   end
 
-  def test_find_first_key
-    assert_equal "08", @decryptor.find_first_key(14, 6)
-    assert_equal "20", @decryptor.find_first_key(26, 6)
+
+  def test_find_all_potential_keys
+    assert_equal [["08", "35", "62", "89"], ["02", "29", "56", "83"], ["03", "30", "57", "84"], ["04", "31", "58", "85"]], @decryptor.find_all_potential_keys("vjqtbeaweqihssi", "291018")
   end
 
-  def test_find_next_key_value
-    key = "08"
-    @decryptor.find_next_key_value(key, 1, 3, 5)
-    assert_equal "083", key
-    @decryptor.find_next_key_value(key, 2, 2, 5)
-    assert_equal "0830", key
-    @decryptor.find_next_key_value(key, 3, 4, 8)
-    assert_equal "08304", key
+  def test_find_working_keys
+    assert_equal ["08", "83", "30", "04"], @decryptor.find_working_keys("vjqtbeaweqihssi", "291018")
+  end
+
+  def test_combine_keys
+    assert_equal "08304", @decryptor.combine_keys(["08", "83", "30", "04"])
+  end
+
+  def test_key_is_valid
+    assert_equal true, @decryptor.key_is_valid?(["02", "29", "56", "83"], "08")
+    assert_equal false, @decryptor.key_is_valid?(["02", "29", "56", "83"], "89")
+  end
+
+  def test_find_next_valid_key
+    assert_equal "83", @decryptor.find_next_valid_key(["02", "29", "56", "83"], "08")
+  end
+
+  def test_first_key_value
+    assert_equal "09", @decryptor.first_key_value(9)
+    assert_equal "12", @decryptor.first_key_value(12)
+  end
+
+  def test_shifts_minus_offsets_when_finding_potential_keys
+    assert_equal [8, 2, 3, 4], @decryptor.shifts_minus_offsets("vjqtbeaweqihssi", "291018")
   end
 
 end

--- a/test/decryptor_test.rb
+++ b/test/decryptor_test.rb
@@ -103,6 +103,10 @@ class DecryptorTest < Minitest::Test
     key = "08"
     @decryptor.find_next_key_value(key, 1, 3, 5)
     assert_equal "083", key
+    @decryptor.find_next_key_value(key, 2, 2, 5)
+    assert_equal "0830", key
+    @decryptor.find_next_key_value(key, 3, 4, 8)
+    assert_equal "08304", key
   end
 
 end


### PR DESCRIPTION
This is a complete refactor of the find_key method used for cracking without the key. I realized
 I needed to check all possible key values for each (shift - offset) so I made subarrays of possible keys by adding multiples of 27 to the values then checking if each value was valid by comparing it to the next set of possible key values. It sometimes returns the wrong key if there is a valid key with lower numbers than the original key used.